### PR TITLE
🗑️ 不要な`extends`フィールドを`renovate.json5`から削除

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,3 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>tqer39/renovate-config"
-  ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }


### PR DESCRIPTION

## 📒 変更概要

- `renovate.json5`ファイルから不要な`extends`フィールドが削除されました。

## ⚒ 技術的詳細

- `renovate.json5`ファイルの以下のフィールドが削除されました:
  - `"extends": ["github>tqer39/renovate-config"]`
- `$schema`フィールドはそのまま残されています。

## ⚠ 注意点

- 💡 この変更は、`renovate.json5`の設定に影響を与える可能性があります。設定の動作を確認してください。